### PR TITLE
[fix_name_implementation] - Replace the hard coded getName to class conical name

### DIFF
--- a/library/src/main/java/net/rafaeltoledo/okir/OkHttp3IdlingResource.java
+++ b/library/src/main/java/net/rafaeltoledo/okir/OkHttp3IdlingResource.java
@@ -43,7 +43,7 @@ public class OkHttp3IdlingResource implements Interceptor, IdlingResource {
 
     @Override
     public String getName() {
-        return "net.rafaeltoledo.okhttpidlingresource.OkHttp3IdlingResource";
+        return OkHttp3IdlingResource.class.getCanonicalName();
     }
 
     @Override

--- a/library/src/main/java/net/rafaeltoledo/okir/OkHttpIdlingResource.java
+++ b/library/src/main/java/net/rafaeltoledo/okir/OkHttpIdlingResource.java
@@ -43,7 +43,7 @@ public class OkHttpIdlingResource implements Interceptor, IdlingResource {
 
     @Override
     public String getName() {
-        return "net.rafaeltoledo.okhttpidlingresource.OkHttpIdlingResource";
+        return OkHttpIdlingResource.class.getCanonicalName();
     }
 
     @Override


### PR DESCRIPTION
Change the `getName()` method using the `Class.getConicalName()` instead using hardcoded name